### PR TITLE
Fix bug related to saving roles

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -4,8 +4,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Set;
 import java.util.Optional;
+import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
@@ -72,9 +72,13 @@ public class ParserUtil {
     public static Set<Role> parseRoles(Collection<String> roles) throws ParseException {
         requireNonNull(roles);
         final Set<Role> roleSet = new HashSet<>();
-        for (String roleName : roles) {
-            if (!roleName.trim().isEmpty()) {
-                roleSet.add(parseRole(roleName));
+        for (String roleNames : roles) {
+            String[] roleNameSplit = roleNames.split(Role.PARSE_ROLE_DELIMITER);
+
+            for (String roleName : roleNameSplit) {
+                if (!roleName.trim().isEmpty()) {
+                    roleSet.add(parseRole(roleName));
+                }
             }
         }
         return roleSet;
@@ -168,7 +172,9 @@ public class ParserUtil {
             String allCoursesString = courseSet.stream()
                 .map((course) -> course.getCourseName())
                 .reduce("", (current, next) -> current + next.toString() + "  ");
-            return new ParseException(String.format(Tutorial.INVALID_COURSE_MESSAGE, courseTutorialName[0], allCoursesString));
+            return new ParseException(String.format(
+                        Tutorial.INVALID_COURSE_MESSAGE, courseTutorialName[0], allCoursesString
+                        ));
         });
 
         return parsedTutorial;

--- a/src/main/java/seedu/address/model/person/Role.java
+++ b/src/main/java/seedu/address/model/person/Role.java
@@ -3,11 +3,6 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-
 /**
  * Represents a Person's address in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidRoleType(String)}
@@ -24,13 +19,20 @@ public class Role {
         Professor
     }
 
-    public static final String MESSAGE_CONSTRAINTS = "Roles must take one of the roleTypes: Student, TA, or Professor.";
+    public static final String MESSAGE_CONSTRAINTS =
+        "A role must take one of the roleTypes: Student, TA, or Professor.";
 
     /*
      * The Role must be either one of Student, TA or Professor.
      */
-    public static final String VALIDATION_REGEX = "^(Student|TA|Professor)(, (Student|TA|Professor))*$";
-    public final Set<RoleType> roleType;
+    public static final String VALIDATION_REGEX = "^(Student|TA|Professor)$";
+
+    /**
+     * Delimiter used when multiple roles are specified in the same command.
+     * May be used as a shorthand for PREFIX_ROLE A PREFIX_ROLE B by doing PREFIX_ROLE A PARSE_ROLE_DELIMTIER B.
+     */
+    public static final String PARSE_ROLE_DELIMITER = ", ";
+    public final RoleType roleType;
 
 
     /**
@@ -41,19 +43,12 @@ public class Role {
     public Role(String roleString) {
         requireNonNull(roleString);
         checkArgument(isValidRoleType(roleString), MESSAGE_CONSTRAINTS);
-        roleType = new HashSet<>();
-        String[] roleTypeStrings = roleString.split(",");
-        for (String roleTypeStr : roleTypeStrings) {
-            roleType.add(RoleType.valueOf(roleTypeStr.trim()));
-        }
+
+        roleType = RoleType.valueOf(roleString);
     }
 
-    public Set<RoleType> getRoleType() {
+    public RoleType getRoleType() {
         return roleType;
-    }
-
-    public String getRoleTypesAsString() {
-        return roleType.stream().map(Enum::toString).collect(Collectors.joining(", "));
     }
 
     /**
@@ -65,7 +60,7 @@ public class Role {
 
     @Override
     public String toString() {
-        return getRoleTypesAsString();
+        return roleType.toString();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Tutorial.java
+++ b/src/main/java/seedu/address/model/person/Tutorial.java
@@ -71,7 +71,8 @@ public class Tutorial {
      * Given a set of courses, finds the course matching the course name given by the tutoralString.
      *
      * @param courses        the Set of Courses to look through.
-     * @param tutorialString the string representing the course and tutorial names, separated by COURSE_TUTORIAL_DELIMITER.
+     * @param tutorialString the string representing the course and tutorial names,
+     *                       separated by COURSE_TUTORIAL_DELIMITER.
      * @return               an Optional containing the Course that may (or may not) be found in the Set.
      */
     public static Optional<Course> findMatchingCourse(Set<Course> courses, String tutorialString) {

--- a/src/main/java/seedu/address/storage/JsonAdaptedRole.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedRole.java
@@ -25,7 +25,7 @@ class JsonAdaptedRole {
      * Converts a given {@code Role} into this class for Jackson use.
      */
     public JsonAdaptedRole(Role source) {
-        roleName = source.roleType.toString();
+        roleName = source.toString();
     }
 
     @JsonValue

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -1,11 +1,14 @@
 package seedu.address.ui;
 
+import java.util.stream.Collectors;
+
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Role;
 
 /**
  * An UI component that displays information of a {@code Person}.
@@ -68,6 +71,6 @@ public class PersonCard extends UiPart<Region> {
                 .reduce("", (current, next) -> current + next));
 
         roles.setText(ROLES_BEGIN_STRING + person.getRoles().stream().map((roles) -> roles.toString())
-                .reduce("", (current, next) -> current + next));
+                .collect(Collectors.joining(Role.PARSE_ROLE_DELIMITER)));
     }
 }


### PR DESCRIPTION
Previously, a bug existed where roles could not be saved properly, leading to corrupted save data.

Let's fix this bug by changing Role to only contain one RoleType, while editing the ParserUtil to delimit role strings into separate individual roles instead. This should fix the problem with role saving.

The delimiter for parsing multiple roleTypes can be found in Role.java. Additionally, the UI has been updated to support this change.