### PR TITLE
Fix bug related to list UI

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -77,6 +77,10 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         String peopleList = "";
 
+
+
+        requireNonNull(model);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         numPeople = model.getFilteredPersonList().size();
         s = numPeople == 1 ? "" : "s";
         model.getFilteredPersonList().forEach((people) -> {
@@ -93,8 +97,6 @@ public class ListCommand extends Command {
                     + courseToString(courseList.get(i)) + enter + tutorialToString(tutorialList.get(i)) + "\n";
         }
 
-        requireNonNull(model);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult("You have " + numPeople + " profile" + s + " in your list\n" + peopleList);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -76,9 +76,6 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         String peopleList = "";
-
-
-
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         numPeople = model.getFilteredPersonList().size();

--- a/src/main/java/seedu/address/model/person/RoleContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/RoleContainsKeywordsPredicate.java
@@ -1,6 +1,6 @@
 package seedu.address.model.person;
 
-import java.util.ArrayList;
+
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -12,8 +12,12 @@ import seedu.address.commons.util.ToStringBuilder;
 public class RoleContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
 
+    /**
+     * Constructs a RoleContainsKeywordsPredicate.
+     *
+     * @param keywords A list of keywords to filter roles by.
+     */
     public RoleContainsKeywordsPredicate(List<String> keywords) {
-
         this.keywords = keywords;
     }
 

--- a/src/main/java/seedu/address/model/person/RoleContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/RoleContainsKeywordsPredicate.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -12,6 +13,7 @@ public class RoleContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
 
     public RoleContainsKeywordsPredicate(List<String> keywords) {
+
         this.keywords = keywords;
     }
 


### PR DESCRIPTION
Previously, a bug existed when entering a list command after search command, resulting a list command which is filtered by the search command keyword. Let's fix it by updating the people's list before updating the people's list text.