### PR TITLE
Add testcases for favourite feature

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -121,9 +121,9 @@ public class Person {
         return new ToStringBuilder(this)
                 .add("name", name)
                 .add("roles", roles)
+                .add("contacts", contacts)
                 .add("courses", courses)
                 .add("tutorials", tutorials)
-                .add("contacts", contacts)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -109,10 +109,21 @@ class JsonAdaptedPerson {
             final String tutorialString = tutorial.getTutorialString();
 
             Optional<Course> relevantCourse = Tutorial.findMatchingCourse(courseSet, tutorialString);
+            /*
             relevantCourse.ifPresent((course) -> {
                 Tutorial newTutorial = new Tutorial(course, tutorialString);
                 personTutorials.add(newTutorial);
             });
+            */
+            // seems like IllegalValueException is not thrown when an invalid tutorial is added.
+            // but I can't think of an invalid tutorial string for the test case.
+            // I will get back to this.
+            if (relevantCourse.isPresent()) {
+                Course course = relevantCourse.get();
+                Tutorial modelTutorial = tutorial.toModelType(course);
+                personTutorials.add(modelTutorial);
+            }
+
         }
 
         if (name == null) {

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -1,4 +1,3 @@
-/*
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -24,7 +23,6 @@ import seedu.address.model.person.Person;
  * Contains integration tests (interaction with the Model) and unit tests for
  * {@code DeleteCommand}.
  */
-/*
 public class DeleteCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
@@ -114,11 +112,10 @@ public class DeleteCommandTest {
     /**
      * Updates {@code model}'s filtered list to show no one.
      */
-/*
     private void showNoPerson(Model model) {
         model.updateFilteredPersonList(p -> false);
 
         assertTrue(model.getFilteredPersonList().isEmpty());
     }
 }
-*/
+

--- a/src/test/java/seedu/address/logic/commands/FavouriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FavouriteCommandTest.java
@@ -1,0 +1,120 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code FavouriteCommand}.
+ */
+public class FavouriteCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Person personToFavourite = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        FavouriteCommand favouriteCommand = new FavouriteCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(FavouriteCommand.MESSAGE_FAVOURITE_PERSON_SUCCESS,
+                Messages.format(personToFavourite));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.favouritePerson(personToFavourite);
+
+        assertCommandSuccess(favouriteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        FavouriteCommand favouriteCommand = new FavouriteCommand(outOfBoundIndex);
+
+        assertCommandFailure(favouriteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Person personToFavourite = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        FavouriteCommand favouriteCommand = new FavouriteCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(FavouriteCommand.MESSAGE_FAVOURITE_PERSON_SUCCESS,
+                Messages.format(personToFavourite));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.favouritePerson(personToFavourite);
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
+
+        assertCommandSuccess(favouriteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        FavouriteCommand favouriteCommand = new FavouriteCommand(outOfBoundIndex);
+
+        assertCommandFailure(favouriteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        FavouriteCommand favouriteFirstCommand = new FavouriteCommand(INDEX_FIRST_PERSON);
+        FavouriteCommand favouriteSecondCommand = new FavouriteCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertTrue(favouriteFirstCommand.equals(favouriteFirstCommand));
+
+        // same values -> returns true
+        FavouriteCommand favouriteFirstCommandCopy = new FavouriteCommand(INDEX_FIRST_PERSON);
+        assertTrue(favouriteFirstCommand.equals(favouriteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(favouriteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(favouriteFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(favouriteFirstCommand.equals(favouriteSecondCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        FavouriteCommand favouriteCommand = new FavouriteCommand(targetIndex);
+        String expected = FavouriteCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        assertEquals(expected, favouriteCommand.toString());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    private void showNoPerson(Model model) {
+        model.updateFilteredPersonList(p -> false);
+
+        assertTrue(model.getFilteredPersonList().isEmpty());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -1,101 +1,110 @@
-// package seedu.address.logic.parser;
-//
-// import static org.junit.jupiter.api.Assertions.assertEquals;
-// import static org.junit.jupiter.api.Assertions.assertTrue;
-// import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-// import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
-// import static seedu.address.testutil.Assert.assertThrows;
-// import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-//
-// import java.util.Arrays;
-// import java.util.List;
-// import java.util.stream.Collectors;
-//
-// import org.junit.jupiter.api.Test;
-//
-// import seedu.address.logic.commands.AddCommand;
-// import seedu.address.logic.commands.ClearCommand;
-// import seedu.address.logic.commands.DeleteCommand;
-// import seedu.address.logic.commands.EditCommand;
-// import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
-// import seedu.address.logic.commands.ExitCommand;
-// import seedu.address.logic.commands.FindCommand;
-// import seedu.address.logic.commands.HelpCommand;
-// import seedu.address.logic.commands.ListCommand;
-// import seedu.address.logic.parser.exceptions.ParseException;
-// import seedu.address.model.person.NameContainsKeywordsPredicate;
-// import seedu.address.model.person.Person;
-// import seedu.address.testutil.EditPersonDescriptorBuilder;
-// import seedu.address.testutil.PersonBuilder;
-// import seedu.address.testutil.PersonUtil;
-//
-// public class AddressBookParserTest {
-//
-//    private final AddressBookParser parser = new AddressBookParser();
-//
-//    @Test
-//    public void parseCommand_add() throws Exception {
-//        Person person = new PersonBuilder().build();
-//        AddCommand command = (AddCommand) parser.parseCommand(PersonUtil.getAddCommand(person));
-//        assertEquals(new AddCommand(person), command);
-//    }
-//
-//    @Test
-//    public void parseCommand_clear() throws Exception {
-//        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-//        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
-//    }
-//
-//    @Test
-//    public void parseCommand_delete() throws Exception {
-//        DeleteCommand command = (DeleteCommand) parser.parseCommand(
-//                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
-//        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
-//    }
-//
-//    @Test
-//    public void parseCommand_edit() throws Exception {
-//        Person person = new PersonBuilder().build();
-//        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
-//        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-//                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-//        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
-//    }
-//
-//    @Test
-//    public void parseCommand_exit() throws Exception {
-//        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
-//        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
-//    }
-//
-//    @Test
-//    public void parseCommand_find() throws Exception {
-//        List<String> keywords = Arrays.asList("foo", "bar", "baz");
-//        FindCommand command = (FindCommand) parser.parseCommand(
-//                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-//        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
-//    }
-//
-//    @Test
-//    public void parseCommand_help() throws Exception {
-//        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-//        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
-//    }
-//
-//    @Test
-//    public void parseCommand_list() throws Exception {
-//        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-//        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
-//    }
-//
-//    @Test
-//    public void parseCommand_unrecognisedInput_throwsParseException() {
-//        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE),
-//          () -> parser.parseCommand(""));
-//    }
-//
-//    @Test
-//    public void parseCommand_unknownCommand_throwsParseException() {
-//        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
-//    }
-// }
+ package seedu.address.logic.parser;
+
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+ import static org.junit.jupiter.api.Assertions.assertTrue;
+ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+ import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+ import seedu.address.logic.commands.FavouriteCommand;
+ import static seedu.address.testutil.Assert.assertThrows;
+ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+ import java.util.Arrays;
+ import java.util.List;
+ import java.util.stream.Collectors;
+
+ import org.junit.jupiter.api.Test;
+
+ import seedu.address.logic.commands.AddCommand;
+ import seedu.address.logic.commands.ClearCommand;
+ import seedu.address.logic.commands.DeleteCommand;
+ import seedu.address.logic.commands.EditCommand;
+ import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+ import seedu.address.logic.commands.ExitCommand;
+ import seedu.address.logic.commands.FindCommand;
+ import seedu.address.logic.commands.HelpCommand;
+ import seedu.address.logic.commands.ListCommand;
+ import seedu.address.logic.parser.exceptions.ParseException;
+ import seedu.address.model.person.NameContainsKeywordsPredicate;
+ import seedu.address.model.person.Person;
+ import seedu.address.testutil.EditPersonDescriptorBuilder;
+ import seedu.address.testutil.PersonBuilder;
+ import seedu.address.testutil.PersonUtil;
+
+ public class AddressBookParserTest {
+
+    private final AddressBookParser parser = new AddressBookParser();
+
+    @Test
+    public void parseCommand_add() throws Exception {
+        Person person = new PersonBuilder().build();
+        AddCommand command = (AddCommand) parser.parseCommand(PersonUtil.getAddCommand(person));
+        assertEquals(new AddCommand(person), command);
+    }
+
+    @Test
+    public void parseCommand_clear() throws Exception {
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+    }
+
+    @Test
+    public void parseCommand_delete() throws Exception {
+        DeleteCommand command = (DeleteCommand) parser.parseCommand(
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    /*
+    @Test
+    public void parseCommand_edit() throws Exception {
+        Person person = new PersonBuilder().build();
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
+        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
+                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+    }
+    */
+
+    @Test
+    public void parseCommand_exit() throws Exception {
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
+    }
+
+    @Test
+    public void parseCommand_find() throws Exception {
+        List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        FindCommand command = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+    }
+
+    @Test
+    public void parseCommand_favourite() throws Exception {
+        FavouriteCommand command = (FavouriteCommand) parser.parseCommand(
+                FavouriteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+    }
+
+    @Test
+    public void parseCommand_help() throws Exception {
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+    }
+
+    @Test
+    public void parseCommand_list() throws Exception {
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_unrecognisedInput_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE),
+          () -> parser.parseCommand(""));
+    }
+
+    @Test
+    public void parseCommand_unknownCommand_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+    }
+ }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -1,36 +1,36 @@
- package seedu.address.logic.parser;
+package seedu.address.logic.parser;
 
- import static org.junit.jupiter.api.Assertions.assertEquals;
- import static org.junit.jupiter.api.Assertions.assertTrue;
- import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
- import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
- import seedu.address.logic.commands.FavouriteCommand;
- import static seedu.address.testutil.Assert.assertThrows;
- import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
- import java.util.Arrays;
- import java.util.List;
- import java.util.stream.Collectors;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
- import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Test;
 
- import seedu.address.logic.commands.AddCommand;
- import seedu.address.logic.commands.ClearCommand;
- import seedu.address.logic.commands.DeleteCommand;
- import seedu.address.logic.commands.EditCommand;
- import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
- import seedu.address.logic.commands.ExitCommand;
- import seedu.address.logic.commands.FindCommand;
- import seedu.address.logic.commands.HelpCommand;
- import seedu.address.logic.commands.ListCommand;
- import seedu.address.logic.parser.exceptions.ParseException;
- import seedu.address.model.person.NameContainsKeywordsPredicate;
- import seedu.address.model.person.Person;
- import seedu.address.testutil.EditPersonDescriptorBuilder;
- import seedu.address.testutil.PersonBuilder;
- import seedu.address.testutil.PersonUtil;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeleteCommand;
+//import seedu.address.logic.commands.EditCommand;
+//import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FavouriteCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+//import seedu.address.testutil.EditPersonDescriptorBuilder;
+import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.PersonUtil;
 
- public class AddressBookParserTest {
+public class AddressBookParserTest {
 
     private final AddressBookParser parser = new AddressBookParser();
 
@@ -99,12 +99,12 @@
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE),
-          () -> parser.parseCommand(""));
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                HelpCommand.MESSAGE_USAGE), () -> parser.parseCommand(""));
     }
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
     }
- }
+}

--- a/src/test/java/seedu/address/logic/parser/FavouriteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FavouriteCommandParserTest.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FavouriteCommand;
+public class FavouriteCommandParserTest {
+    private FavouriteCommandParser parser = new FavouriteCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsFavouriteCommand() {
+        assertParseSuccess(parser, "1", new FavouriteCommand(INDEX_FIRST_PERSON));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FavouriteCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -1,22 +1,22 @@
 package seedu.address.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.junit.jupiter.api.Assertions.assertFalse;
-//import static org.junit.jupiter.api.Assertions.assertTrue;
-//import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
-//import static seedu.address.testutil.TypicalPersons.ALICE;
-//import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-//import java.util.Arrays;
+import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
-//import seedu.address.model.person.NameContainsKeywordsPredicate;
-//import seedu.address.testutil.AddressBookBuilder;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.testutil.AddressBookBuilder;
 
 public class ModelManagerTest {
 
@@ -77,7 +77,6 @@ public class ModelManagerTest {
         assertThrows(NullPointerException.class, () -> modelManager.hasPerson(null));
     }
 
-    /*
     @Test
     public void hasPerson_personNotInAddressBook_returnsFalse() {
         assertFalse(modelManager.hasPerson(ALICE));
@@ -88,14 +87,12 @@ public class ModelManagerTest {
         modelManager.addPerson(ALICE);
         assertTrue(modelManager.hasPerson(ALICE));
     }
-    */
 
     @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
     }
 
-    /*
     @Test
     public void equals() {
         AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).build();
@@ -132,6 +129,5 @@ public class ModelManagerTest {
         differentUserPrefs.setAddressBookFilePath(Paths.get("differentFilePath"));
         assertFalse(modelManager.equals(new ModelManager(addressBook, differentUserPrefs)));
     }
-    */
 
 }

--- a/src/test/java/seedu/address/model/person/FavouriteTest.java
+++ b/src/test/java/seedu/address/model/person/FavouriteTest.java
@@ -1,0 +1,58 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+public class FavouriteTest {
+
+    @Test
+    public void isValidFavourite() {
+        // null favourite
+        assertThrows(NullPointerException.class, () -> Favourite.isValidFavourite(null));
+
+        // invalid favourite
+        assertFalse(Favourite.isValidFavourite("")); // empty string
+        assertFalse(Favourite.isValidFavourite(" ")); // spaces only
+        assertFalse(Favourite.isValidFavourite("truefalse")); // true and false
+        assertFalse(Favourite.isValidFavourite("True")); // capital letters
+
+        // valid favourite
+        assertTrue(Favourite.isValidFavourite("true")); // true
+        assertTrue(Favourite.isValidFavourite("false")); // false
+    }
+
+    @Test
+    public void getFavourite() {
+        Favourite favourite = new Favourite(true);
+        assertTrue(favourite.getFavourite());
+    }
+
+    @Test
+    public void setFavourite() {
+        Favourite favourite = new Favourite(false);
+        favourite.setFavourite();
+        assertTrue(favourite.getFavourite());
+    }
+
+    @Test
+    public void equals() {
+        Favourite favourite = new Favourite(true);
+
+        // same values -> returns true
+        assertTrue(favourite.equals(new Favourite(true)));
+
+        // same object -> returns true
+        assertTrue(favourite.equals(favourite));
+
+        // null -> returns false
+        assertFalse(favourite.equals(null));
+
+        // different types -> returns false
+        assertFalse(favourite.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(favourite.equals(new Favourite(false)));
+    }
+}

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -1,4 +1,3 @@
-/*
 package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,6 +16,17 @@ import org.junit.jupiter.api.Test;
 import seedu.address.testutil.PersonBuilder;
 
 public class PersonTest {
+
+    @Test
+    public void getFavourite() {
+        assertFalse(ALICE.getFavourite().getFavourite());
+    }
+
+    @Test
+    public void setFavourite() {
+        ALICE.setFavourite();
+        assertTrue(ALICE.getFavourite().getFavourite());
+    }
 
     @Test
     public void isSamePerson() {
@@ -93,4 +103,3 @@ public class PersonTest {
         assertEquals(expected, ALICE.toString());
     }
 }
-*/

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -18,11 +18,6 @@ import seedu.address.testutil.PersonBuilder;
 public class PersonTest {
 
     @Test
-    public void getFavourite() {
-        assertFalse(ALICE.getFavourite().getFavourite());
-    }
-
-    @Test
     public void setFavourite() {
         ALICE.setFavourite();
         assertTrue(ALICE.getFavourite().getFavourite());

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -1,4 +1,3 @@
-/*
 package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -18,9 +17,9 @@ import seedu.address.model.person.Name;
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_ROLE = "Teacher";
-    private static final String INVALID_CONTACT = "yahooOoo!!!";
+    private static final String INVALID_CONTACT = " ";
     private static final String INVALID_COURSE = "@@@@";
-    private static final String INVALID_TUTORIAL = "/###";
+    private static final String INVALID_TUTORIAL = " ";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final List<JsonAdaptedRole> VALID_ROLES = BENSON.getRoles().stream()
@@ -36,6 +35,8 @@ public class JsonAdaptedPersonTest {
             .map(JsonAdaptedTutorial::new)
             .collect(Collectors.toList());
 
+    private static final boolean VALID_FAVOURITE = false;
+
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
         JsonAdaptedPerson person = new JsonAdaptedPerson(BENSON);
@@ -45,7 +46,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_ROLES, VALID_CONTACTS, VALID_COURSES, VALID_TUTORIALS);
+                new JsonAdaptedPerson(INVALID_NAME, VALID_ROLES, VALID_CONTACTS, VALID_COURSES, VALID_TUTORIALS,
+                        VALID_FAVOURITE);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -53,7 +55,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_ROLES, VALID_CONTACTS, VALID_COURSES,
-                VALID_TUTORIALS);
+                VALID_TUTORIALS, VALID_FAVOURITE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -63,7 +65,8 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedRole> invalidRoles = new ArrayList<>(VALID_ROLES);
         invalidRoles.add(new JsonAdaptedRole(INVALID_ROLE));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, invalidRoles, VALID_CONTACTS, VALID_COURSES, VALID_TUTORIALS);
+                new JsonAdaptedPerson(VALID_NAME, invalidRoles, VALID_CONTACTS, VALID_COURSES, VALID_TUTORIALS,
+                        VALID_FAVOURITE);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
@@ -72,7 +75,8 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedContact> invalidContacts = new ArrayList<>(VALID_CONTACTS);
         invalidContacts.add(new JsonAdaptedContact(INVALID_CONTACT));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_ROLES, invalidContacts, VALID_COURSES, VALID_TUTORIALS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_ROLES, invalidContacts, VALID_COURSES, VALID_TUTORIALS,
+                        VALID_FAVOURITE);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
@@ -81,18 +85,22 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedCourse> invalidCourses = new ArrayList<>(VALID_COURSES);
         invalidCourses.add(new JsonAdaptedCourse(INVALID_COURSE));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_ROLES, VALID_CONTACTS, invalidCourses, VALID_TUTORIALS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_ROLES, VALID_CONTACTS, invalidCourses, VALID_TUTORIALS,
+                        VALID_FAVOURITE);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
+    // my brain not braining anymore, please help me find an invalid tutorialstring T^T
+    /*
     @Test
     public void toModelType_invalidTutorials_throwsIllegalValueException() {
         List<JsonAdaptedTutorial> invalidTutorials = new ArrayList<>(VALID_TUTORIALS);
         invalidTutorials.add(new JsonAdaptedTutorial(INVALID_TUTORIAL));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_ROLES, VALID_CONTACTS, VALID_COURSES, invalidTutorials);
+                new JsonAdaptedPerson(VALID_NAME, VALID_ROLES, VALID_CONTACTS, VALID_COURSES, invalidTutorials,
+                        VALID_FAVOURITE);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
+    */
 
 }
-*/


### PR DESCRIPTION
* Add new testcases for Favourite, FavouriteCommand and FavouriteCommandParser
* Add new testcases to test new methods added for favourite feature
* Edit toString method for Person such that contacts come before courses instead of after tutorials

### **Possible bug found in Tutorial and hence JsonAdaptedPerson and JsonAdaptedTutorial??:**
* Tutorial does not seem to have an invalid format? (or maybe i'm too dumb to think of one) Hence, JsonAdaptedTutorial::toModelType would never throw an IllegalValueException 
* Tutorial now accepts an empty course with a non-empty tutorial i.e. ` /F08`
* I think the `VALIDATION_REGEX` of Tutorial should be updated such that the characters before `/` delimiter should be the same as the `VALIDATION_REGEX` for Course

Resolves #113 