### PR TITLE
Update PersonBuilder

### DIFF
--- a/src/main/java/seedu/address/model/person/Tutorial.java
+++ b/src/main/java/seedu/address/model/person/Tutorial.java
@@ -22,7 +22,7 @@ public class Tutorial {
     // A tutorial String is in the format of courseName + COURSE_TUTORIAL_DELIMITER + tutorialName.
     // This is a constant representing that delimiter.
     public static final String COURSE_TUTORIAL_DELIMITER = "/";
-    public static final String PARSE_TUTORIAL_DELIMITER = ", ";
+    public static final String PARSE_TUTORIAL_DELIMITER = "-";
 
     public final Course course;
     public final String tutorialName;

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -3,7 +3,6 @@ package seedu.address.storage;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -102,28 +102,9 @@ class JsonAdaptedPerson {
             personCourses.add(course.toModelType());
         }
 
-        final Set<Course> courseSet = new HashSet<>(personCourses);
         final List<Tutorial> personTutorials = new ArrayList<>();
         for (JsonAdaptedTutorial tutorial : tutorials) {
-            // Get the course relevant to this tutorial.
-            final String tutorialString = tutorial.getTutorialString();
-
-            Optional<Course> relevantCourse = Tutorial.findMatchingCourse(courseSet, tutorialString);
-            /*
-            relevantCourse.ifPresent((course) -> {
-                Tutorial newTutorial = new Tutorial(course, tutorialString);
-                personTutorials.add(newTutorial);
-            });
-            */
-            // seems like IllegalValueException is not thrown when an invalid tutorial is added.
-            // but I can't think of an invalid tutorial string for the test case.
-            // I will get back to this.
-            if (relevantCourse.isPresent()) {
-                Course course = relevantCourse.get();
-                Tutorial modelTutorial = tutorial.toModelType(course);
-                personTutorials.add(modelTutorial);
-            }
-
+            personTutorials.add(tutorial.toModelType(tutorial.getCourse()));
         }
 
         if (name == null) {

--- a/src/main/java/seedu/address/storage/JsonAdaptedTutorial.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTutorial.java
@@ -36,6 +36,10 @@ class JsonAdaptedTutorial {
         return tutorialString;
     }
 
+    public Course getCourse() {
+        return new Course(tutorialString.split(Tutorial.COURSE_TUTORIAL_DELIMITER)[0]);
+    }
+
     /**
      * Converts this Jackson-friendly adapted tutorial object into the model's {@code Tutorial} object.
      * This requires a reference to an already-converted course to maintain a reference.

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -34,7 +34,7 @@ public class PersonTest {
         // same name, all other attributes different -> returns true
         Person editedAlice = new PersonBuilder(ALICE)
                 .withRoles(VALID_ROLE_TA).withContacts(VALID_CONTACT_BOB)
-                .withCourses(VALID_COURSE_2).withTutorials(VALID_TUTORIAL_2).build();
+                .withCourses(VALID_COURSE_2).withCoursesAndTutorials(VALID_TUTORIAL_2).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
         // different name, all other attributes same -> returns false
@@ -86,7 +86,7 @@ public class PersonTest {
         assertFalse(ALICE.equals(editedAlice));
 
         // different tutorial -> returns false
-        editedAlice = new PersonBuilder(ALICE).withTutorials(VALID_TUTORIAL_2).build();
+        editedAlice = new PersonBuilder(ALICE).withCoursesAndTutorials(VALID_TUTORIAL_2).build();
         assertFalse(ALICE.equals(editedAlice));
     }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -19,7 +19,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_ROLE = "Teacher";
     private static final String INVALID_CONTACT = " ";
     private static final String INVALID_COURSE = "@@@@";
-    private static final String INVALID_TUTORIAL = " ";
+    private static final String INVALID_TUTORIAL = "cs2100/ f";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final List<JsonAdaptedRole> VALID_ROLES = BENSON.getRoles().stream()
@@ -90,8 +90,7 @@ public class JsonAdaptedPersonTest {
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
-    // my brain not braining anymore, please help me find an invalid tutorialstring T^T
-    /*
+
     @Test
     public void toModelType_invalidTutorials_throwsIllegalValueException() {
         List<JsonAdaptedTutorial> invalidTutorials = new ArrayList<>(VALID_TUTORIALS);
@@ -101,6 +100,5 @@ public class JsonAdaptedPersonTest {
                         VALID_FAVOURITE);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
-    */
 
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -94,7 +94,7 @@ public class PersonBuilder {
      * Parses the {@code tutorials} into a stream and collects the Courses of each Tutorial into a {@code Set<Course>}
      * NOTE: This method is used to add both tutorials and courses into the person we are building.
      */
-    public PersonBuilder withTutorials(Tutorial... tutorials) {
+    public PersonBuilder withCoursesAndTutorials(Tutorial... tutorials) {
         this.tutorials = SampleDataUtil.getTutorialSet(tutorials);
         this.courses = Arrays.stream(tutorials)
             .map(Tutorial::getCourse)

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -31,12 +31,12 @@ public class TypicalPersons {
     // ALICE --> all fields present, not favourited
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withRoles(VALID_ROLE_STUDENT).withContacts("alice@example.com")
-            .withTutorials(VALID_TUTORIAL_1).withFavourite(false).build();
+            .withCoursesAndTutorials(VALID_TUTORIAL_1).withFavourite(false).build();
 
     // BENSON --> all fields present, multiple courses with tutorials, not favourited
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withRoles(VALID_ROLE_TA).withContacts("johnd@example.com")
-            .withTutorials(VALID_TUTORIAL_1, VALID_TUTORIAL_2).withFavourite(false).build();
+            .withCoursesAndTutorials(VALID_TUTORIAL_1, VALID_TUTORIAL_2).withFavourite(false).build();
 
     // CARL --> courses and tutorials not present, not favourited
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz")
@@ -65,23 +65,23 @@ public class TypicalPersons {
     // HOON --> all fields present, favourited
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier")
             .withRoles("Student").withContacts("stefan@example.com")
-            .withTutorials(VALID_TUTORIAL_2).withFavourite(true).build();
+            .withCoursesAndTutorials(VALID_TUTORIAL_2).withFavourite(true).build();
 
     // IDA --> all fields present, not favourited
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller")
             .withRoles("TA").withContacts("hans@example.com")
-            .withTutorials(VALID_TUTORIAL_2).withFavourite(false).build();
+            .withCoursesAndTutorials(VALID_TUTORIAL_2).withFavourite(false).build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     // AMY --> all fields present, not favourited
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY)
             .withRoles(VALID_ROLE_STUDENT).withContacts(VALID_CONTACT_AMY)
-            .withTutorials(VALID_TUTORIAL_1).withFavourite(false).build();
+            .withCoursesAndTutorials(VALID_TUTORIAL_1).withFavourite(false).build();
 
     // BOB --> all fields present, favourited
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB)
             .withRoles(VALID_ROLE_TA).withContacts(VALID_CONTACT_BOB)
-            .withTutorials(VALID_TUTORIAL_2).withFavourite(true).build();
+            .withCoursesAndTutorials(VALID_TUTORIAL_2).withFavourite(true).build();
 
     // CHARLIE --> name present only, not favourited
     public static final Person CHARLIE = new PersonBuilder().withName(VALID_NAME_CHARLIE)


### PR DESCRIPTION
* `PersonBuilder::withTutorials` is changed to `PersonBuilder::withCoursesAndTutorials`
* `PARSE_TUTORIAL_DELIMITTER` is changed from `", "` to `"-"` 

Fix bug in JsonAdaptedTutorial
* Previously, JsonAdaptedTutorial::toModelType does not throw IllegalValueException when an invalid tutorial string is given (i.e. "cs2100/ f"), hence causing a testcase in JsonAdaptedPersonTest to fail
* This is due to the problem of getting a Course from a JsonAdaptedTutorial object. 
* Now, a new method, `getCourses` is added to JsonAdaptedTutorial to get the Course of the Tutorial when adding the tutorials to the Person in `JsonAdaptedPerson::toModelType`. 