### PR TITLE
Fix Favourite command GUI bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 
@@ -42,6 +43,8 @@ public class FavouriteCommand extends Command {
 
         Person personToFavourite = lastShownList.get(targetIndex.getZeroBased());
         model.favouritePerson(personToFavourite);
+        model.setPerson(personToFavourite, personToFavourite);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_FAVOURITE_PERSON_SUCCESS,
                 Messages.format(personToFavourite)));
     }

--- a/src/main/java/seedu/address/logic/commands/UnfavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnfavouriteCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 
@@ -42,6 +43,8 @@ public class UnfavouriteCommand extends Command {
 
         Person personToUnfavourite = lastShownList.get(targetIndex.getZeroBased());
         model.unfavouritePerson(personToUnfavourite);
+        model.setPerson(personToUnfavourite, personToUnfavourite);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_UNFAVOURITE_PERSON_SUCCESS,
                 Messages.format(personToUnfavourite)));
     }

--- a/src/test/java/seedu/address/logic/commands/FavouriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FavouriteCommandTest.java
@@ -61,7 +61,6 @@ public class FavouriteCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.favouritePerson(personToFavourite);
-        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
 
         assertCommandSuccess(favouriteCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/UnfavouriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnfavouriteCommandTest.java
@@ -61,7 +61,6 @@ public class UnfavouriteCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.unfavouritePerson(personToUnfavourite);
-        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
 
         assertCommandSuccess(unfavouriteCommand, model, expectedMessage, expectedModel);
     }


### PR DESCRIPTION
Previously, the favourite tag in the person card GUI does not appear or disappear immediately when favourite and unfavourite commands are executed. Now, the favourite tag is displayed immediately when user inputs `fav INDEX` and removed immediately when user inputs `unfav INDEX`. 

Closes #193 
Closes #181 
Closes #202