### PR TITLE
Fix finding multiple keywords in search commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindTutorialCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindTutorialCommand.java
@@ -45,6 +45,7 @@ public class FindTutorialCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
+        System.out.println(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }

--- a/src/main/java/seedu/address/logic/commands/FindTutorialCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindTutorialCommand.java
@@ -45,7 +45,6 @@ public class FindTutorialCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
-        System.out.println(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }

--- a/src/main/java/seedu/address/logic/parser/FindCourseCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCourseCommandParser.java
@@ -32,7 +32,7 @@ public class FindCourseCommandParser implements Parser<FindCourseCommand> {
             throw new ParseException(Course.MESSAGE_CONSTRAINTS);
         }
 
-        String[] courseKeywords = trimmedArgs.split("\\s+");
+        String[] courseKeywords = trimmedArgs.split(Course.PARSE_COURSE_DELIMITER);
 
         return new FindCourseCommand(new CourseContainsKeywordsPredicate(Arrays.asList(courseKeywords)));
     }

--- a/src/main/java/seedu/address/logic/parser/FindRoleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindRoleCommandParser.java
@@ -31,7 +31,7 @@ public class FindRoleCommandParser implements Parser<FindRoleCommand> {
             throw new ParseException(Role.MESSAGE_CONSTRAINTS);
         }
 
-        String[] roleKeywords = trimmedArgs.split("\\s+");
+        String[] roleKeywords = trimmedArgs.split(Role.PARSE_ROLE_DELIMITER);
 
         return new FindRoleCommand(new RoleContainsKeywordsPredicate(Arrays.asList(roleKeywords)));
     }

--- a/src/main/java/seedu/address/logic/parser/FindTutorialCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindTutorialCommandParser.java
@@ -31,9 +31,9 @@ public class FindTutorialCommandParser implements Parser<FindTutorialCommand> {
             throw new ParseException(Tutorial.MESSAGE_CONSTRAINTS);
         }
 
-        String[] roleKeywords = trimmedArgs.split("\\s+");
+        String[] tutorialKeywords = trimmedArgs.split(Tutorial.TUTORIAL_SEPARATOR);
 
-        return new FindTutorialCommand(new TutorialContainsKeywordsPredicate(Arrays.asList(roleKeywords)));
+        return new FindTutorialCommand(new TutorialContainsKeywordsPredicate(Arrays.asList(tutorialKeywords)));
     }
 
     /**


### PR DESCRIPTION
Previously, attempting to search using multiple keywords for the search commands would only yield results of the last keyword entered, due to a bug where the split delimiter was incorrect.

Now, users can search for multiple keywords.