### PR TITLE
Fix bugs related to Add Command 

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -48,6 +48,9 @@ public class AddCommand extends Command {
     public static final String MESSAGE_DUPLICATE_PERSON = "Note: A person with the same name already exists." + "\n"
             + "Please edit the existing person or change the name of this person to be added";
 
+    public static final String MESSAGE_NAME_MISSING = "Note: Compulsory name input is missing"
+            + "\nUnable to add a person without a name";
+
     private final Person toAdd;
 
     /**

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -49,7 +49,7 @@ public class AddCommand extends Command {
             + "Please edit the existing person or change the name of this person to be added";
 
     public static final String MESSAGE_NAME_MISSING = "Note: Compulsory name input is missing"
-            + "\nUnable to add a person without a name";
+            + "\nUnable to add a person without name";
 
     private final Person toAdd;
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -35,9 +35,12 @@ public class AddCommandParser implements Parser<AddCommand> {
                     PREFIX_ROLE, PREFIX_CONTACT,
                     PREFIX_COURSE);
 
-        if (!arePrefixesPresent(argMultimap)
-                || !argMultimap.getPreamble().isEmpty()) {
+        if (!argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        }
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_NAME_MISSING));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_ROLE, PREFIX_CONTACT, PREFIX_COURSE);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -6,10 +6,10 @@ package seedu.address.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("--name");
-    public static final Prefix PREFIX_ROLE = new Prefix("--role");
-    public static final Prefix PREFIX_CONTACT = new Prefix("--contact");
-    public static final Prefix PREFIX_COURSE = new Prefix("--course");
+    public static final Prefix PREFIX_NAME = new Prefix("--name ");
+    public static final Prefix PREFIX_ROLE = new Prefix("--role ");
+    public static final Prefix PREFIX_CONTACT = new Prefix("--contact ");
+    public static final Prefix PREFIX_COURSE = new Prefix("--course ");
     public static final Prefix PREFIX_TUTORIAL = new Prefix("--tutorial");
     public static final Prefix PREFIX_ADD = new Prefix("--add");
     public static final Prefix PREFIX_DELETE = new Prefix("--delete");

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -78,6 +78,8 @@ public class ParserUtil {
             for (String roleName : roleNameSplit) {
                 if (!roleName.trim().isEmpty()) {
                     roleSet.add(parseRole(roleName));
+                } else {
+                    throw new ParseException(Role.MESSAGE_CONSTRAINTS);
                 }
             }
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -147,7 +147,8 @@ public class ParserUtil {
             String[] splitCourse = courseNames.split(Course.PARSE_COURSE_DELIMITER);
             for (String courseName : splitCourse) {
                 if (!courseName.trim().isEmpty()) {
-                    courseSet.add(parseCourse(courseName));
+                    String courseNameUpperCase = courseName.toUpperCase();
+                    courseSet.add(parseCourse(courseNameUpperCase));
                 } else {
                     throw new ParseException(Course.MESSAGE_CONSTRAINTS);
                 }

--- a/src/main/java/seedu/address/model/person/Course.java
+++ b/src/main/java/seedu/address/model/person/Course.java
@@ -56,7 +56,7 @@ public class Course {
         }
 
         Course otherCourse = (Course) other;
-        return courseName.equals(otherCourse.courseName);
+        return courseName.equalsIgnoreCase(otherCourse.courseName);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -56,7 +56,7 @@ public class Name {
         }
 
         Name otherName = (Name) other;
-        return fullName.equals(otherName.fullName);
+        return fullName.equalsIgnoreCase(otherName.fullName);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Tutorial.java
+++ b/src/main/java/seedu/address/model/person/Tutorial.java
@@ -17,7 +17,7 @@ public class Tutorial {
         "Given course's name (%s) does not match Tutorial's course name (%s).";
 
     // Matches a single character, any number of characters, a slash, a single character, then any number of characters.
-    public static final String VALIDATION_REGEX = "^[A-Za-z]{2,3}\\d{4}[A-Za-z]?\\/[^\\s].*$";
+    public static final String VALIDATION_REGEX = "^[A-Za-z]{2,3}\\d{4}[A-Za-z]?\\/[A-Za-z0-9]*-?[A-Za-z0-9].*$";
 
     // A tutorial String is in the format of courseName + COURSE_TUTORIAL_DELIMITER + tutorialName.
     // This is a constant representing that delimiter.

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -41,9 +41,9 @@ public class PersonTest {
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";


### PR DESCRIPTION
Previously: 
1. `AddCommandParser` doesn't catch the error when the compulsory `name` field is missing from the user input. 
2. `AddCommand` except the input when user enter an empty role
3. The same course code was treated as different course due to the different case used
4. Name was case sensitive, allowing 2 names with different case to be added
5. Tutorial allows symbols other than hyphen as a valid input
6. Accept `--specifierINPUT` as a valid input when there should be a space between the specifier and the user input 

resolves: 
#196 
#179 
#176 
#175 
#174 
#173 
#171 
#170 
