### PR TITLE
Fix bug related to Add Command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -6,10 +6,10 @@ package seedu.address.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("--name ");
-    public static final Prefix PREFIX_ROLE = new Prefix("--role ");
-    public static final Prefix PREFIX_CONTACT = new Prefix("--contact ");
-    public static final Prefix PREFIX_COURSE = new Prefix("--course ");
+    public static final Prefix PREFIX_NAME = new Prefix("--name");
+    public static final Prefix PREFIX_ROLE = new Prefix("--role");
+    public static final Prefix PREFIX_CONTACT = new Prefix("--contact");
+    public static final Prefix PREFIX_COURSE = new Prefix("--course");
     public static final Prefix PREFIX_TUTORIAL = new Prefix("--tutorial");
     public static final Prefix PREFIX_ADD = new Prefix("--add");
     public static final Prefix PREFIX_DELETE = new Prefix("--delete");

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,8 +11,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_CONTACT = new Prefix("--contact");
     public static final Prefix PREFIX_COURSE = new Prefix("--course");
     public static final Prefix PREFIX_TUTORIAL = new Prefix("--tutorial");
-    public static final Prefix PREFIX_ADD = new Prefix("--add");
-    public static final Prefix PREFIX_DELETE = new Prefix("--delete");
-    public static final Prefix PREFIX_CHANGE = new Prefix("--change");
 
 }


### PR DESCRIPTION
In the previous bug fix #238 , the format of the specifier was changed, causing the `AddCommandParser` to be unable to recognize the correct specifier.
This commit changed the specifier back to its original specifier so it can be recognised.