### PR TITLE
Revert issues that violated feature freeze

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -206,7 +206,8 @@ Show the help page of the application
 `help`
 
 ###### ACCEPTABLE VALUES:
-This command does not accept any parameters
+Command accepts parameters after the keyword `help`, i.e. `help im dying` but they will be ignored 
+and the `help` command will still be executed.
 
 ###### EXPECTED OUTPUT ON SUCCESS:
 
@@ -234,10 +235,6 @@ This command only recognises `help` as the keyword.
 Any other command word such as `h`, `he` and `hel` will be seen as an invalid command with the following output:
 
 `Unknown command`
-
-> 📝Note:
->
-> Anything after `help`, i.e. `help im dying` will be ignored and the `help` command will still be executed.
 
 
 <div style="page-break-after: always;"></div>
@@ -415,7 +412,8 @@ List all the persons added by the user.
 `list`
 
 ###### ACCEPTABLE VALUES:
-This command does not accept any parameters.
+Command accepts parameters after the keyword `list`, i.e. `list everything` but they will be ignored 
+and the `list` command will still be executed.
 
 ###### EXPECTED OUTPUT ON SUCCESS:
 ```
@@ -439,12 +437,6 @@ Tutorials: CS1101S/Tut8
 This command only recognises `list` as the keyword. 
 
 Any other command word such as `l`, `li` and `lis` will be seen as an invalid command with the following output:
-
-`Unknown command`
-
-> 📝Note:
-> 
-> Anything after `list`, i.e. `list hello` will be ignored and the `list` command will still be executed.
 
 
 <div style="page-break-after: always;"></div>
@@ -551,7 +543,8 @@ List all the persons favourited by the user.
 `favlist`
 
 ###### ACCEPTABLE VALUES:
-This command does not accept any parameters.
+Command accepts parameters after the keyword `favlist`, i.e. `favlist hehe` but they will be ignored 
+and the `favlist` command will still be executed.
 
 ###### EXPECTED OUTPUT ON SUCCESS:
 *(if user has only favourited 1 person)*
@@ -570,10 +563,6 @@ This command only recognises `favlist` as the keyword.
 Any other command word such as `favl`, `favli` and `favlis` will be seen as an invalid command with the following output:
 
 `Unknown command`
-
-> 📝Note:
->
-> Anything after `favlist`, i.e. `favlist hello` will be ignored and the `favlist` command will still be executed.
 
 
 <div style="page-break-after: always;"></div>
@@ -784,6 +773,34 @@ Example: searchtutorial CS2100/G07
 
 <div style="page-break-after: always;"></div>
 
+### Clearing the person list: `clear`
+
+Clears the address book.
+
+###### FORMAT:
+`clear`
+
+###### EXAMPLE COMMAND:
+`clear`
+
+###### ACCEPTABLE VALUES:
+Command accepts parameters after the keyword `clear`, i.e. `clear your mind` but they will be ignored 
+and the `clear` command will still be executed. 
+
+###### EXPECTED OUTPUT ON SUCCESS:
+```
+All persons have been cleared!
+```
+
+###### EXPECTED OUTPUT ON FAILURE:
+This command only recognises `clear` as the keyword.
+
+Any other command word such as `c`, `cl` and `clea` will be seen as an invalid command with the following output:
+
+`Unknown command`
+
+<div style="page-break-after: always;"></div>
+
 ### Exiting the application: `exit`
 
 Closes and exits the application
@@ -795,7 +812,8 @@ Closes and exits the application
 `exit`
 
 ###### ACCEPTABLE VALUES:
-This command does not accept any parameters
+Command accepts parameters after the keyword `exit`, i.e. `exit world` but they will be ignored and
+the `exit` command will still be executed.
 
 ###### EXPECTED OUTPUT ON SUCCESS:
 There will be no output 
@@ -808,11 +826,6 @@ This command only recognises `exit` as the keyword.
 Any other command word such as `e`, `ex` and `exi` will be seen as an invalid command with the following output:
 
 `Unknown command`
-
-> 📝Note:
->
-> Anything after `exit`, i.e. `exit hello` will be ignored and the `exit` command will still be executed.
-
 
 <div style="page-break-after: always;"></div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -235,12 +235,10 @@ Any other command word such as `h`, `he` and `hel` will be seen as an invalid co
 
 `Unknown command`
 
-Command with extra parameter(s) after the keyword will throw error: `help 1`
-```
-Invalid command format! 
-help: Shows program usage instructions.
-Example: help
-```
+> 📝Note:
+>
+> Anything after `help`, i.e. `help im dying` will be ignored and the `help` command will still be executed.
+
 
 <div style="page-break-after: always;"></div>
 
@@ -444,6 +442,10 @@ Any other command word such as `l`, `li` and `lis` will be seen as an invalid co
 
 `Unknown command`
 
+> 📝Note:
+> 
+> Anything after `list`, i.e. `list hello` will be ignored and the `list` command will still be executed.
+
 
 <div style="page-break-after: always;"></div>
 
@@ -555,6 +557,11 @@ This command does not accept any parameters.
 *(if user has only favourited 1 person)*
 ```
 You have 1 favourited person in your list. 
+Name: Aiken Dueet  
+Role: STUDENT
+Contact: [[@aikendueet], [aikendueet@gmail.com]]
+Course: CS2103T, CS2101, CS2100
+Tutorials: CS2103T/Tut8 , CS2101/G06, CS2100/Lab40-Tut30 
 ```
 
 ###### EXPECTED OUTPUT ON FAILURE:
@@ -563,6 +570,11 @@ This command only recognises `favlist` as the keyword.
 Any other command word such as `favl`, `favli` and `favlis` will be seen as an invalid command with the following output:
 
 `Unknown command`
+
+> 📝Note:
+>
+> Anything after `favlist`, i.e. `favlist hello` will be ignored and the `favlist` command will still be executed.
+
 
 <div style="page-break-after: always;"></div>
 
@@ -796,6 +808,11 @@ This command only recognises `exit` as the keyword.
 Any other command word such as `e`, `ex` and `exi` will be seen as an invalid command with the following output:
 
 `Unknown command`
+
+> 📝Note:
+>
+> Anything after `exit`, i.e. `exit hello` will be ignored and the `exit` command will still be executed.
+
 
 <div style="page-break-after: always;"></div>
 

--- a/src/main/java/seedu/address/logic/commands/FavListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavListCommand.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
+import java.util.stream.Collectors;
 
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
@@ -48,10 +48,26 @@ public class FavListCommand extends Command {
         int numbFavouritePeople = favouritePersons.size();
         String s = numbFavouritePeople == 1 ? "" : "s";
 
-        Stream<Person> peopleList = favouritePersons.stream();
+        String peopleList = favouritePersons.stream()
+                .map(this::formatPersonDetails)
+                .collect(Collectors.joining("\n"));
 
         return new CommandResult("You have " + numbFavouritePeople
-                + " favourited person" + s + " in your list.\n");
+                + " favourited person" + s + " in your list.\n" + peopleList);
+    }
+
+    /**
+     * Format the details of a person to a string representation.
+     *
+     * @param person The person whose details need to be formatted.
+     * @return A string with the formatted details of the person.
+     */
+    private String formatPersonDetails(Person person) {
+        return "Name: " + person.getName() + "\n"
+                + "Roles: " + person.getRoles() + "\n"
+                + "Contacts: " + person.getContacts() + "\n"
+                + "Courses: " + person.getCourses() + "\n"
+                + "Tutorials: " + person.getTutorials() + "\n";
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -105,18 +105,7 @@ public class AddressBookParser {
 
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
-        if (commandWord.equals("list") && !arguments.equals("")) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
-        }
-        if (commandWord.equals("clear") && !arguments.equals("")) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ClearCommand.MESSAGE_USAGE));
-        }
-        if (commandWord.equals("help") && !arguments.equals("")) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
-        }
-        if (commandWord.equals("favlist") && !arguments.equals("")) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FavListCommand.MESSAGE_USAGE));
-        }
+
         // Note to developers: Change the log level in config.json to enable lower-level
         // (i.e., FINE, FINER, and lower) log messages such as the one below.
         // Lower-level log messages are used sparingly to minimize noise in the code.

--- a/src/test/java/seedu/address/logic/commands/FavListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FavListCommandTest.java
@@ -1,6 +1,11 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_CONTACT_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_COURSE_2;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ROLE_TA;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TUTORIAL_2;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BOB;
@@ -44,7 +49,12 @@ public class FavListCommandTest {
         Model model = new ModelManager();
         model.addPerson(new PersonBuilder(BOB).build());
         CommandResult result = new FavListCommand().execute(model);
-        String expectedOutput = "You have 1 favourited person in your list.\n";
+        String expectedOutput = "You have 1 favourited person in your list.\n"
+                + "Name: " + VALID_NAME_BOB + "\n"
+                + "Roles: " + "[" + VALID_ROLE_TA + "]" + "\n"
+                + "Contacts: " + "[" + "[" + VALID_CONTACT_BOB + "]" + "]" + "\n"
+                + "Courses: " + "[" + VALID_COURSE_2.toString() + "]" + "\n"
+                + "Tutorials: " + "[" + VALID_TUTORIAL_2.toString() + "]" + "\n";;
         assertEquals(expectedOutput, result.getFeedbackToUser());
     }
 
@@ -63,7 +73,12 @@ public class FavListCommandTest {
         model.addPerson(AMY);
         model.addPerson(BOB);
         CommandResult result = new FavListCommand().execute(model);
-        String expectedOutput = "You have 1 favourited person in your list.\n";
+        String expectedOutput = "You have 1 favourited person in your list.\n"
+                + "Name: " + VALID_NAME_BOB + "\n"
+                + "Roles: " + "[" + VALID_ROLE_TA + "]" + "\n"
+                + "Contacts: " + "[" + "[" + VALID_CONTACT_BOB + "]" + "]" + "\n"
+                + "Courses: " + "[" + VALID_COURSE_2.toString() + "]" + "\n"
+                + "Tutorials: " + "[" + VALID_TUTORIAL_2.toString() + "]" + "\n";;
         assertEquals(expectedOutput, result.getFeedbackToUser());
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -57,8 +57,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    ClearCommand.MESSAGE_USAGE), () -> parser.parseCommand(ClearCommand.COMMAND_WORD + " 3"));
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
     }
 
     @Test
@@ -145,22 +144,19 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    HelpCommand.MESSAGE_USAGE), () -> parser.parseCommand(HelpCommand.COMMAND_WORD + " 3"));
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
     }
 
     @Test
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    ListCommand.MESSAGE_USAGE), () -> parser.parseCommand(ListCommand.COMMAND_WORD + " 3"));
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
     }
 
     @Test
     public void parseCommand_favlist() throws Exception {
         assertTrue(parser.parseCommand(FavListCommand.COMMAND_WORD) instanceof FavListCommand);
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    FavListCommand.MESSAGE_USAGE), () -> parser.parseCommand(FavListCommand.COMMAND_WORD + " 3"));
+        assertTrue(parser.parseCommand(FavListCommand.COMMAND_WORD + " 3") instanceof FavListCommand);
     }
 
     @Test


### PR DESCRIPTION
1. Previously, a fix changed the output message when users input `favlist`. This is a violation of feature freeze, hence the fix is reverted. 
 
Closes #253 

2. Previously, the pe-d bug reports mentioned that single commands i.e. `help`, `list`, `favlist`, `clear` and `exit` does not show error messages when parameters are added after these commands. The error messages should show as per UG. We fixed in such that it would throw an error but this is a violation of feature freeze hence we revert these fixes and update the UG instead. 

Closes #252 