### PR TITLE
Revert some changes in PR #238

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -148,8 +148,7 @@ public class ParserUtil {
             String[] splitCourse = courseNames.split(Course.PARSE_COURSE_DELIMITER);
             for (String courseName : splitCourse) {
                 if (!courseName.trim().isEmpty()) {
-                    String courseNameUpperCase = courseName.toUpperCase();
-                    courseSet.add(parseCourse(courseNameUpperCase));
+                    courseSet.add(parseCourse(courseName));
                 } else {
                     throw new ParseException(Course.MESSAGE_CONSTRAINTS);
                 }

--- a/src/main/java/seedu/address/model/person/Course.java
+++ b/src/main/java/seedu/address/model/person/Course.java
@@ -56,7 +56,7 @@ public class Course {
         }
 
         Course otherCourse = (Course) other;
-        return courseName.equalsIgnoreCase(otherCourse.courseName);
+        return courseName.equals(otherCourse.courseName);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -56,7 +56,7 @@ public class Name {
         }
 
         Name otherName = (Name) other;
-        return fullName.equalsIgnoreCase(otherName.fullName);
+        return fullName.equals(otherName.fullName);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Tutorial.java
+++ b/src/main/java/seedu/address/model/person/Tutorial.java
@@ -17,7 +17,7 @@ public class Tutorial {
         "Given course's name (%s) does not match Tutorial's course name (%s).";
 
     // Matches a single character, any number of characters, a slash, a single character, then any number of characters.
-    public static final String VALIDATION_REGEX = "^[A-Za-z]{2,3}\\d{4}[A-Za-z]?\\/[A-Za-z0-9]*-?[A-Za-z0-9].*$";
+    public static final String VALIDATION_REGEX = "^[A-Za-z]{2,3}\\d{4}[A-Za-z]?\\/[^\\s].*$";
 
     // A tutorial String is in the format of courseName + COURSE_TUTORIAL_DELIMITER + tutorialName.
     // This is a constant representing that delimiter.

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -41,14 +41,14 @@ public class PersonTest {
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // name differs in case, all other attributes same -> returns true
+        // name differs in case, all other attributes same -> returns false
         Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertTrue(BOB.isSamePerson(editedBob));
+        assertFalse(BOB.isSamePerson(editedBob));
 
-        // name has trailing spaces, all other attributes same -> returns true
+        // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertTrue(BOB.isSamePerson(editedBob));
+        assertFalse(BOB.isSamePerson(editedBob));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -45,10 +45,10 @@ public class PersonTest {
         Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
         assertTrue(BOB.isSamePerson(editedBob));
 
-        // name has trailing spaces, all other attributes same -> returns false
+        // name has trailing spaces, all other attributes same -> returns true
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
     }
 
     @Test


### PR DESCRIPTION
Previously in PR #238 , some changes made violates feature freeze. Those changes are reverted in this PR back to its original.

In PR #238 :
1. The input for `--course` was changed to case-insensitive, but this change is not allowed during feaure freeze. Hence the case sensitivity of the course input was revert back to before PR #238 
2. The same problem also applies to the input for `--name` 
3. In PR #238 , the tutorial validation regex was changed to reject symbols input other than hyphen but this change is considered as feature flaw. Hence this PR revert the validation regex for tutorial back to before PR #238 
4. The test result for `PersonTest` was changed due to the change in the case sensitivity for `name` input. 